### PR TITLE
NeutronMemberV2: adding operating_status

### DIFF
--- a/core/src/main/java/com/huawei/openstack4j/model/network/ext/MemberV2.java
+++ b/core/src/main/java/com/huawei/openstack4j/model/network/ext/MemberV2.java
@@ -60,4 +60,10 @@ public interface MemberV2  extends ModelEntity, Buildable<MemberV2Builder> {
      */
     boolean isAdminStateUp();
 
+    /**
+     * @return the health check state of the member, which is one of ONLINE,
+     *         OFFLINE, NO_MONITOR
+     */
+    String getOperatingStatus();
+
 }

--- a/core/src/main/java/com/huawei/openstack4j/model/network/ext/builder/MemberV2Builder.java
+++ b/core/src/main/java/com/huawei/openstack4j/model/network/ext/builder/MemberV2Builder.java
@@ -94,4 +94,12 @@ public interface MemberV2Builder extends Buildable.Builder<MemberV2Builder, Memb
      * @return MemberV2Builder
      */
     MemberV2Builder adminStateUp(boolean adminStateUp);
+
+    /**
+     * the health check state of the member, which is one of ONLINE, OFFLINE,
+     * NO_MONITOR
+     * 
+     * @return {@link MemberV2Builder}
+     */
+    MemberV2Builder operatingStatus(String operatingStatus);
 }

--- a/core/src/main/java/com/huawei/openstack4j/openstack/networking/domain/ext/NeutronMemberV2.java
+++ b/core/src/main/java/com/huawei/openstack4j/openstack/networking/domain/ext/NeutronMemberV2.java
@@ -72,6 +72,9 @@ public class NeutronMemberV2 implements MemberV2 {
     @JsonProperty("admin_state_up")
     private boolean adminStateUp = true;
 
+    @JsonProperty("operating_status")
+    private String operatingStatus;
+
     /**
      * {@inheritDoc}
      */
@@ -139,6 +142,7 @@ public class NeutronMemberV2 implements MemberV2 {
                 .add("adminStateUp", adminStateUp)
                 .add("weight",weight)
                 .add("subnetId",subnetId)
+                .add("operatingStatus", operatingStatus)
                 .toString();
     }
 
@@ -250,6 +254,16 @@ public class NeutronMemberV2 implements MemberV2 {
 			m.name = name;
             return this;
 		}
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public MemberV2Builder operatingStatus(String operatingStatus) {
+            m.operatingStatus = operatingStatus;
+            return this;
+        }
+
     }
 
     @Override
@@ -259,5 +273,13 @@ public class NeutronMemberV2 implements MemberV2 {
 
     public static MemberV2Builder builder(){
         return new MemberV2ConcreteBuilder();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOperatingStatus() {
+        return operatingStatus;
     }
 }


### PR DESCRIPTION
Hi,

can we make the operational status accessible?
https://docs.otc.t-systems.com/api/elb/elb_zq_hd_0003.html

Thanks, 
Georg